### PR TITLE
Fix wchar escape behavior in input and outputs

### DIFF
--- a/server/graph-output.R
+++ b/server/graph-output.R
@@ -61,7 +61,7 @@ plotInput <- reactive({
     offset = input$offset,
     x = if(is.null(input$nodeposMatrix[,"x"]) | !setequal(input$nodeposMatrix[,"Hypothesis"], input$hypothesesMatrix[,"Name"])){NULL} else{as.numeric(input$nodeposMatrix[,"x"])},
     y = if(is.null(input$nodeposMatrix[,"y"]) | !setequal(input$nodeposMatrix[,"Hypothesis"], input$hypothesesMatrix[,"Name"])){NULL} else{as.numeric(input$nodeposMatrix[,"y"])},
-    wchar = input$wchar
+    wchar = stringi::stri_unescape_unicode(input$wchar)
   )
 
 

--- a/ui/tabset-sidebar.R
+++ b/ui/tabset-sidebar.R
@@ -62,7 +62,7 @@ headingPanel(
           sliderInput("height", "Ellipsis Height", 0, 1, .5, .01),
           numericInput("size", "Hypothesis Text Size", 8, 1, 10, 1),
           numericInput("digits", "# Digits for Significance Level", 3, 1, 6, 1),
-          textInput("wchar", "Significance Level Symbol", "\u03b1"),
+          textInput("wchar", "Significance Level Symbol", "\\u03b1"),
           br(),
           h4("Set the Positions"),
           uiOutput("initnodepos"),


### PR DESCRIPTION
This PR fixes the `wchar` escape behavior in the text input and code output. Still works ok for the plot output.