### PR TITLE
Unescape unicode inputs for hypothesis name and group name

### DIFF
--- a/server/graph-output.R
+++ b/server/graph-output.R
@@ -10,7 +10,7 @@ output$initnodepos <- renderUI({
                 "Node position matrix",
                 helpPopover(
                   "nodeposMatrix",
-                  "The hypothesis input uses the plotmath syntax. See ?grDevices::plotmath for details. Use \\n to add a line break.
+                  "The text input supports Unicode escape sequence like \\uABCD. Use \\n to add a line break.
                             The x, y coordinates are for the relative position of the hypothesis ellipses."
                 )
               ),
@@ -39,12 +39,12 @@ plotInput <- reactive({
 
   gMCPmini::hGraph(
     nHypotheses = nrow(input$hypothesesMatrix),
-    nameHypotheses = input$hypothesesMatrix[,"Name"],
+    nameHypotheses = stringi::stri_unescape_unicode(input$hypothesesMatrix[,"Name"]),
     alphaHypotheses = as.numeric(input$hypothesesMatrix[,"Alpha"]),
     m = m,
     fill = input$hypothesesMatrix[,"Group"],
     palette = hgraph_palette(pal_name = input$pal_name, n = length(unique(input$hypothesesMatrix[,"Group"])), alpha = input$pal_alpha),
-    labels = input$hypothesesMatrix[,"Group"],
+    labels = stringi::stri_unescape_unicode(input$hypothesesMatrix[,"Group"]),
     legend.name = input$legend.name,
     legend.position = input$legendPosition,
     halfWid = input$width,

--- a/ui/tabset-sidebar.R
+++ b/ui/tabset-sidebar.R
@@ -14,7 +14,7 @@ headingPanel(
           "Hypotheses matrix",
           helpPopover(
             "hypothesesMatrix",
-            "Name and Group need text input, and Alpha need numeric input. The text input uses the plotmath syntax. See ?grDevices::plotmath for details. Use \\n to add a line break."
+            "Name and Group need text input, and Alpha needs numeric input. The text inputs support Unicode escape sequence like \\uABCD. Use \\n to add a line break."
           )
         ),
         value = as.matrix(data.frame(cbind(

--- a/ui/tabset-sidebar.R
+++ b/ui/tabset-sidebar.R
@@ -14,7 +14,7 @@ headingPanel(
           "Hypotheses matrix",
           helpPopover(
             "hypothesesMatrix",
-            "Name and Group need text input, and Alpha needs numeric input. The text inputs support Unicode escape sequence like \\uABCD. Use \\n to add a line break."
+            "Name and Group need text input, and Alpha needs numeric input. The text inputs support Unicode escape sequence, like \\uABCD for special symbols and \\n for adding a line break. See `?Quotes` for details"
           )
         ),
         value = as.matrix(data.frame(cbind(

--- a/ui/tabset-sidebar.R
+++ b/ui/tabset-sidebar.R
@@ -14,7 +14,7 @@ headingPanel(
           "Hypotheses matrix",
           helpPopover(
             "hypothesesMatrix",
-            "Name and Group need text input, and Alpha needs numeric input. The text inputs support Unicode escape sequence, like \\uABCD for special symbols and \\n for adding a line break. See `?Quotes` for details"
+            "Name and Group need text input, and Alpha needs numeric input. The text inputs support Unicode escape sequence, like \\uABCD for a special symbol and \\n for adding a line break. See ?Quotes for details."
           )
         ),
         value = as.matrix(data.frame(cbind(


### PR DESCRIPTION
This PR fixes https://github.com/allenzhuaz/hgraphapp/issues/7.

Now the hypotheses names and group names can display the newline character `\n` (and any Unicode characters, too) in the plot output.