### PR TITLE
Use ragg and clean up old plot code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,11 +3,12 @@ Title: hGraph Shiny App
 Type: Shiny
 Version: 2022.06.0
 Imports:
-    colourpicker,
-    rhandsontable,
-    shinyMatrix,
+    brew,
+    bslib,
+    gMCPmini,
+    markdown,
+    ragg,
     shiny,
-    dplyr,
-    ggplot2,
-    reshape2,
-    stringr
+    shinyjs,
+    shinyMatrix,
+    stringi

--- a/app.R
+++ b/app.R
@@ -5,6 +5,7 @@ library(shinyjs)
 library(markdown)
 library(gMCPmini)
 library(shinyMatrix)
+library(ragg)
 
 # Global modules and functions -------------------------------------------------
 
@@ -19,6 +20,11 @@ source("modules/sanitize-filename.R")
 source("modules/df2graph.R")
 source("modules/adaptive-palette.R")
 
+# Use `ragg::agg_png()` for plot outputs to make them cross-platform consistent.
+# Importantly, this makes ellipse edges look smooth with proper anti-aliasing.
+# Note this is experimental in shiny and may be superseded in the future.
+# See <https://github.com/rstudio/shiny/blob/main/R/imageutils.R>
+options(shiny.useragg = TRUE)
 
 # UI ---------------------------------------------------------------------------
 

--- a/server/graph-output.R
+++ b/server/graph-output.R
@@ -68,7 +68,6 @@ plotInput <- reactive({
 })
 
 output$thePlot <- renderPlot({
-  print(parseQueryString(session$clientData$url_search))
   print(plotInput())
 })
 outputOptions(output, "thePlot", suspendWhenHidden = FALSE) # thePlot runs even when not visible

--- a/ui/main.R
+++ b/ui/main.R
@@ -22,8 +22,6 @@ navbarPageCustom(
   header = tags$head(
     tags$link(rel = "shortcut icon", type = "image/png", href = "images/favicon.png"),
     tags$link(rel = "stylesheet", type = "text/css", href = "css/custom.css"),
-    # Custom JS to enable downloading PNG from DOM
-    tags$script(src = "js/download-plot.js"),
     tags$script(src = "js/help-popover.js")
   ),
   source("ui/hgraph.R", local = TRUE)$value,

--- a/ui/tabset-main.R
+++ b/ui/tabset-main.R
@@ -1,9 +1,5 @@
 headingPanel(
   "Outputs",
-
-  # Custom HTML to trigger JS which downloads image from DOM
-  # HTML('<a href="#" role="button" class="btn btn-default" onclick="prepHref(this)" download><i class="fa fa-download"></i>Download Image</a>'),
-
   tabsetPanel(
     tabPanel(
       "Graph",

--- a/www/js/download-plot.js
+++ b/www/js/download-plot.js
@@ -1,5 +1,0 @@
-function prepHref(linkElement) {
-  var myDiv = document.getElementById("thePlot");
-  var myImage = myDiv.children[0];
-  linkElement.href = myImage.src;
-}


### PR DESCRIPTION
This PR

- Introduces `options(shiny.useragg = TRUE)` to use the `ragg::agg_png()` graphical device for plot outputs. This makes the plot consistent across platforms (Windows, Linux, Mac). Most importantly, this makes the ellipse edges look smooth with proper anti-aliasing (shinyapps.io Linux output has rough edges).
- Removed unused plot-related code from previous implementation. Particularly, removing the `print(parseQueryString(...))` line fixes the constant `list()` being print out in the console.

You should deploy to shinyapps.io again and check if this works there.