### PR TITLE
hot fix for displaying "1e-n" bug (specific for shiny server)

### DIFF
--- a/server/graph-output.R
+++ b/server/graph-output.R
@@ -1,3 +1,4 @@
+options(scipen = 999) #Enforce disabling scientific notation
 
 # Initial node position uioutput
 output$initnodepos <- renderUI({


### PR DESCRIPTION
In the shinyapps.io server, the very small number, such as `0.00001` will be display as `1e-05`. Just avoid it by using `scipen` in global option setting.