### PR TITLE
Redesign nodepos

### DIFF
--- a/server/graph-matrix-buttons.R
+++ b/server/graph-matrix-buttons.R
@@ -43,13 +43,6 @@ observeEvent(input$btn_trwtMatrix_reset, {
 })
 
 # Node position
-observeEvent(input$btn_nodeposMatrix_addrow, {
-  updateMatrixInput(session, inputId = "nodeposMatrix", value = addMatrixRow(input$nodeposMatrix))
-})
-
-observeEvent(input$btn_nodeposMatrix_delrow, {
-  updateMatrixInput(session, inputId = "nodeposMatrix", value = delMatrixRow(input$nodeposMatrix))
-})
 
 observeEvent(input$btn_nodeposMatrix_reset, {
   radianStart <- if((nrow(input$hypothesesMatrix))%%2 != 0) {

--- a/server/graph-matrix-buttons.R
+++ b/server/graph-matrix-buttons.R
@@ -43,6 +43,13 @@ observeEvent(input$btn_trwtMatrix_reset, {
 })
 
 # Node position
+observeEvent(input$btn_hypothesesMatrix_addrow, {
+  updateMatrixInput(session, inputId = "nodeposMatrix", value = addMatrixRow(input$nodeposMatrix))
+})
+
+observeEvent(input$btn_hypothesesMatrix_delrow, {
+  updateMatrixInput(session, inputId = "nodeposMatrix", value = delMatrixRow(input$nodeposMatrix))
+})
 
 observeEvent(input$btn_nodeposMatrix_reset, {
   radianStart <- if((nrow(input$hypothesesMatrix))%%2 != 0) {

--- a/server/graph-output.R
+++ b/server/graph-output.R
@@ -1,31 +1,5 @@
 options(scipen = 999) #Enforce disabling scientific notation
 
-# Initial node position uioutput
-output$initnodepos <- renderUI({
-  radianStart <- if((nrow(input$hypothesesMatrix))%%2 != 0) {
-    pi * (1/2 + 1/nrow(input$hypothesesMatrix)) } else {
-      pi * (1 + 2/nrow(input$hypothesesMatrix))/2 }
-
-  matrixInput("nodeposMatrix",
-              label = tagList(
-                "Customize Node Position",
-                helpPopover(
-                  "Node Position Matrix",
-                  "The \"Hypotheses\" text inputs support Unicode escape sequence, like `\\uABCD` for a special symbol and `\\n` for adding a line break. See `?Quotes` for details.
-                  The \"x\", \"y\" numeric inputs are coordinates for the relative position of the hypothesis ellipses."
-                )
-              ),
-              value = as.matrix(data.frame(cbind(Hypothesis = input$hypothesesMatrix[,"Name"],
-                                                 x = round(2 * cos((radianStart - (0:(nrow(input$hypothesesMatrix)-1))/nrow(input$hypothesesMatrix)*2*pi) %% (2*pi)), 6),
-                                                 y = round(2 * sin((radianStart - (0:(nrow(input$hypothesesMatrix)-1))/nrow(input$hypothesesMatrix)*2*pi) %% (2*pi)), 6)
-              ))),
-              class = "character",
-              rows = list(names = FALSE, editableNames = FALSE, extend = FALSE),
-              cols = list(names = TRUE, editableNames = FALSE, extend = FALSE)
-  )
-})
-outputOptions(output, name = "initnodepos", suspendWhenHidden = FALSE)
-
 
 # Create plot ------------------------------------------------------------------
 

--- a/ui/tabset-sidebar.R
+++ b/ui/tabset-sidebar.R
@@ -69,8 +69,31 @@ headingPanel(
           numericInput("digits", "# Digits for Significance Level", 5, 1, 12, 1),
           textInput("wchar", "Significance Level Symbol", "\\u03b1"),
 
-          uiOutput("initnodepos"),
-          matrixButtonGroup("nodeposMatrix")
+          matrixInput("nodeposMatrix",
+                      label = tagList(
+                        "Customize Node Position",
+                        helpPopover(
+                          "Node Position Matrix",
+                          "The \"Hypotheses\" text inputs support Unicode escape sequence, like `\\uABCD` for a special symbol and `\\n` for adding a line break. See `?Quotes` for details.
+                  The \"x\", \"y\" numeric inputs are coordinates for the relative position of the hypothesis ellipses."
+                        )
+                      ),
+                      value = as.matrix(data.frame(cbind(Hypothesis = paste0("H", 1:4),
+                                                         x = c(-1, 1, 1, -1),
+                                                         y = c(1, 1, -1, -1)
+                      ))),
+                      class = "character",
+                      rows = list(names = FALSE, editableNames = FALSE, extend = FALSE),
+                      cols = list(names = TRUE, editableNames = FALSE, extend = FALSE)
+          ),
+          actionButton(
+            "btn_nodeposMatrix_reset",
+            label = "",
+            icon = icon("undo"),
+            width = "100%",
+            class = "btn btn-block btn-outline-primary"
+          ),
+          p(icon("exclamation-triangle"), "Press the", icon("undo"),  "button will recover to default circular layout"),
         ), # end Ellipses subtab
 
         tabPanel(


### PR DESCRIPTION
In this redesign update:
* When add a new hypothesis (in `hypothesisMatrix`), a new row will be automatically added in node position matrix, with all blanks in  Hypothesis and x-y coordinator. $\rightarrow$ The output plot will not display the new node until user enter numeric values in "x" and "y" columns, and enter the same value as the new hypothesis' name in "Hypothesis" column. Output still keep original layout for other nodes if user do not change them.
* When delete an existing hypothesis, the corresponding row will be automatically deleted from node position matrix. $\rightarrow$ The output plot will automatically drop the node, and still keep original layout for other nodes.
* When click the reset button under the node position matrix, "Hypothesis" will be automatically updated to match the hypotheses names in `hypothesisMatrix`, "x" and "y" columns will be updated as circular layout positions. $\rightarrow$ The whole output plot will automatically update as circular layout [**Not recommended for editing an existing graph, especially a complex graph with many nodes**]