### PR TITLE
Show prompt before go back, forward, refresh, or close page

### DIFF
--- a/server/save-restore.R
+++ b/server/save-restore.R
@@ -59,14 +59,15 @@ observeEvent(input$btn_design_restore, {
   ))
 
   lapply(
+    names(hgraph_inputs)[is_matrix_input],
+    function(x) updateMatrixInput(session, inputId = x, value = hgraph_inputs[[x]])
+  )
+
+  lapply(
     names(hgraph_inputs)[!is_matrix_input],
     function(x) session$sendInputMessage(x, list(value = hgraph_inputs[[x]]))
   )
 
-  lapply(
-    names(hgraph_inputs)[is_matrix_input],
-    function(x) updateMatrixInput(session, inputId = x, value = hgraph_inputs[[x]])
-  )
 
   # Restore global reactive values
   node_settings <- lst$node_settings

--- a/server/show-example.R
+++ b/server/show-example.R
@@ -34,14 +34,15 @@ observeEvent(input$btn_show_example, {
     FUN = function(x) "matrix" %in% x
   ))
 
-  lapply(
-    names(hgraph_inputs)[!is_matrix_input],
-    function(x) session$sendInputMessage(x, list(value = hgraph_inputs[[x]]))
-  )
 
   lapply(
     names(hgraph_inputs)[is_matrix_input],
     function(x) updateMatrixInput(session, inputId = x, value = hgraph_inputs[[x]])
+  )
+
+  lapply(
+    names(hgraph_inputs)[!is_matrix_input],
+    function(x) session$sendInputMessage(x, list(value = hgraph_inputs[[x]]))
   )
 
   # Restore global reactive values

--- a/ui/main.R
+++ b/ui/main.R
@@ -22,7 +22,8 @@ navbarPageCustom(
   header = tags$head(
     tags$link(rel = "shortcut icon", type = "image/png", href = "images/favicon.png"),
     tags$link(rel = "stylesheet", type = "text/css", href = "css/custom.css"),
-    tags$script(src = "js/help-popover.js")
+    tags$script(src = "js/help-popover.js"),
+    tags$script(src = "js/beforeunload.js")
   ),
   source("ui/hgraph.R", local = TRUE)$value,
   source("ui/gmcp.R", local = TRUE)$value,

--- a/www/js/beforeunload.js
+++ b/www/js/beforeunload.js
@@ -1,0 +1,5 @@
+// Show a prompt to prevent users from accidentally
+// go back, forward, refresh, or close the page
+window.onbeforeunload = function () {
+    return 'Your changes will be lost!';
+};


### PR DESCRIPTION
This PR adds a JavaScript solution to avoid unintentional loss of work if the user **accidentally** goes back, forward, refresh, or closes the browser tab.

If there are any changes made in the app and the user does any of the above four things, a browser prompt window will show and ask if the user wants to leave site and "changes you made may not be saved".