### PR TITLE
Improve UI consistency and accessibility

### DIFF
--- a/modules/help-popover.R
+++ b/modules/help-popover.R
@@ -10,3 +10,12 @@ helpPopover <- function(title, content) {
     shiny::icon("question-circle")
   )
 }
+
+helpLink <- function(href) {
+  tags$a(
+    href = href,
+    target = "_blank",
+    class = "help-popover",
+    shiny::icon("external-link-alt")
+  )
+}

--- a/modules/input-file-button.R
+++ b/modules/input-file-button.R
@@ -20,7 +20,7 @@ fileButtonInput <- function(inputId, label, multiple = FALSE, accept = NULL, wid
     inputTag$attribs$accept <- paste(accept, collapse = ",")
   }
   div(
-    style = "display: inline-block; width: 10rem; margin-bottom: -2rem;", # not super elegant but works
+    style = "display: inline-block; width: 10rem; margin-bottom: -2rem; margin-right: -3px;", # not super elegant but works
     div(
       class = "form-group shiny-input-container", style = if (!is.null(width)) {
         paste0("width: ", validateCssUnit(width), ";")

--- a/server/display-settings.R
+++ b/server/display-settings.R
@@ -1,87 +1,136 @@
 # Create a reactive value object to maintain the settings globally
-rv_nodes <- reactiveValues("wchar" = "\\u03b1", "digits" = 5, "width" = .75, "height" = .5, "size" = 8, "pal_name" = "gray", "pal_alpha" = 0.6,  "trdigits" = 4)
+rv_nodes <- reactiveValues(
+  "wchar" = "\\u03b1",
+  "digits" = 5,
+  "width" = .75,
+  "height" = .5,
+  "size" = 8,
+  "pal_name" = "gray",
+  "pal_alpha" = 0.6,
+  "trdigits" = 4
+)
 
 # Display settings modal (from Hypothesis tab)
 observeEvent(input$btn_node_setting_modal, {
   showModal(modalDialog(
     title = "Node Display Settings",
-
-    h5("Node Shape and Text Format", style = "margin-top: 0;"),
+    h5("Node shape and text format", style = "margin-top: 0.5rem;"),
     hr(),
-
     fluidRow(
       column(
         width = 3,
-    numericInput("width", "Width: ", min = 0, max = 1, value = rv_nodes$width, step = .01)),
-
+        numericInput(
+          "width",
+          label = tagList(
+            "Width:",
+            helpPopover(
+              "halfWid",
+              "Half width of ellipses."
+            )
+          ),
+          value = rv_nodes$width, min = 0, max = 1, step = .01
+        )
+      ),
       column(
         width = 3,
-    numericInput("height", "Height: ", min = 0, max = 1, value = rv_nodes$height, step = .01)),
-
-    column(
-      width = 3,
-      numericInput("digits",
-                   label = tagList(
-                     "Digits: ",
-                     helpPopover(
-                       "digits",
-                       "Number of digits past the decimal for siginificance level in the hypothesis nodes"
-                     )
-                   ), value = rv_nodes$digits, min = 1, max = 12, step = 1, width = "100%"
-      )),
-
-    column(
-      width = 3,
-    numericInput("size", "Text Size: ", value = rv_nodes$size, min = 1, max = 20, step = 1))),
-
-    h5("Node Symbol and Color", style = "margin-top: 0;"),
+        numericInput(
+          "height",
+          label = tagList(
+            "Height:",
+            helpPopover(
+              "halfHgt",
+              "Half height of ellipses."
+            )
+          ),
+          value = rv_nodes$height, min = 0, max = 1, step = .01
+        )
+      ),
+      column(
+        width = 3,
+        numericInput(
+          "digits",
+          label = tagList(
+            "Digits:",
+            helpPopover(
+              "digits",
+              "Number of digits past the decimal for siginificance level in the hypothesis nodes."
+            )
+          ),
+          value = rv_nodes$digits, min = 1, max = 12, step = 1, width = "100%"
+        )
+      ),
+      column(
+        width = 3,
+        numericInput(
+          "size",
+          label = tagList(
+            "Text size:",
+            helpPopover(
+              "size",
+              "Text size in ellipses."
+            )
+          ),
+          value = rv_nodes$size, min = 1, max = 20, step = 1
+        )
+      )
+    ),
+    h5("Node symbol and colors", style = "margin-top: 1rem;"),
     hr(),
     fluidRow(
-
       column(
-        width = 6,
-        textInput("wchar",
-                  label = tagList(
-                    "Symbol: ",
-                    helpPopover(
-                      "wchar",
-                      "Symbol character to be shown for significance level in the hypothesis nodes.
-                  Input \\unicode for Greek letters, for example \\u03b1 for alpha.
-                  For full dictionary, please refer to http://kestrel.nmt.edu/~raymond/software/howtos/greekscape.xhtml"
-                    )
-                  ), value = rv_nodes$wchar, width = "100%"
-        )),
-
+        width = 4,
+        textInput(
+          "wchar",
+          label = tagList(
+            "Symbol:",
+            helpPopover(
+              "wchar",
+              "Symbol character representing significance level in the hypothesis nodes.
+                  Use Unicode characters for Greek letters, for example, \\u03b1 for alpha.
+                  Click the second icon for a more comprehensive character list."
+            ),
+            helpLink("https://en.wikipedia.org/wiki/List_of_Unicode_characters")
+          ),
+          value = rv_nodes$wchar, width = "100%"
+        )
+      ),
       column(
-        width = 6,
-    selectInput(
-      "pal_name",
-      label = "Palette: ",
-      choices = c(
-        "gray",
-        "Okabe-Ito",
-        "d3.category10",
-        "d3.category20",
-        "d3.category20b",
-        "d3.category20c",
-        "Teal"
-      ), selected = rv_nodes$pal_name
-    ))),
-
-  fluidRow(
-    column(
-      width = 12,
-    sliderInput("pal_alpha",
-                label = tagList(
-                  "Transparency: ",
-                  helpPopover(
-                    "Color Transparency",
-                    "Values range from 0 to 1 , with lower values corresponding to more transparent colors"
-                  )
-                ),
-                min = 0.1, max = 1, value = rv_nodes$pal_alpha, step = 0.01, width = "100%"))),
-
-
+        width = 4,
+        selectInput(
+          "pal_name",
+          label = tagList(
+            "Palette:",
+            helpPopover(
+              "palette",
+              "Colors for groups."
+            )
+          ),
+          choices = c(
+            "gray",
+            "Okabe-Ito",
+            "d3.category10",
+            "d3.category20",
+            "d3.category20b",
+            "d3.category20c",
+            "Teal"
+          ), selected = rv_nodes$pal_name
+        )
+      ),
+      column(
+        width = 4,
+        numericInput(
+          "pal_alpha",
+          label = tagList(
+            "Transparency:",
+            helpPopover(
+              "Color transparency",
+              "Number ranging from 0 to 1, with lower values corresponding to more transparent colors."
+            )
+          ),
+          value = rv_nodes$pal_alpha, min = 0, max = 1, step = 0.01, width = "100%"
+        )
+      )
+    ),
     easyClose = FALSE,
     footer = tagList(
       actionButton("btn_node_settings_save", label = "Save Settings", class = "btn-primary", icon = icon("save")),
@@ -103,89 +152,141 @@ observeEvent(input$btn_node_settings_save, {
 
 
 # Create a reactive value object to maintain the settings globally
-rv_edges <- reactiveValues("trhw" = .13, "trhh" = .1, "trdigits" = 4, "boxtextsize" = 6, "trprop" = .33, "arrowsize" = .035, "offset" = .15)
+rv_edges <- reactiveValues(
+  "trhw" = .13,
+  "trhh" = .1,
+  "trdigits" = 4,
+  "boxtextsize" = 6,
+  "trprop" = .33,
+  "arrowsize" = .035,
+  "offset" = .15
+)
 
 # Display settings modal (from Transition tab)
 observeEvent(input$btn_edge_setting_modal, {
   showModal(modalDialog(
     title = "Edge Display Settings",
-    h5("Transition Box Shape and Text Format", style = "margin-top: 0;"),
+    h5("Transition box shape and text format", style = "margin-top: 0.5rem;"),
     hr(),
     fluidRow(
       column(
         width = 3,
-    numericInput("trhw", "Width", rv_edges$trhw, 0, 1, .01)),
-
-    column(
-      width = 3,
-    numericInput("trhh", "Height", rv_edges$trhh, 0, 1, .01)),
-
-
-    column(
-      width = 3,
-    numericInput("trdigits",
-             label = tagList(
-               "Digits:",
-               helpPopover(
-                 "Digits for Transition Weights",
-                 "Number of digits past the decimal for transition weight in the transition box"
-               )
-             ), value = rv_edges$trdigits, min = 1, max = 10, step = 1, width = "100%"
-      )),
-
-    column(
-      width = 3,
-    numericInput("boxtextsize", "Text Size", rv_edges$boxtextsize, 1, 20, 1))),
-
-    h5("Edge Layout", style = "margin-top: 0;"),
-    hr(),
-
-    fluidRow(
-     column(
-      width = 6,
-    numericInput("arrowsize", "Arrow Size: ", rv_edges$arrowsize, .005, .6, .005)),
-
-    column(
-      width = 6,
-    numericInput("offset", label = tagList(
-      "Offset:",
-      helpPopover(
-        "offset",
-        "Rotational offset in radians for transition edges, can control space between neighbor edges"
+        numericInput(
+          "trhw",
+          label = tagList(
+            "Width:",
+            helpPopover(
+              "trhw",
+              "Transition box width."
+            )
+          ),
+          value = rv_edges$trhw, min = 0, max = 1, step = .01
+        )
+      ),
+      column(
+        width = 3,
+        numericInput(
+          "trhh",
+          label = tagList(
+            "Height:",
+            helpPopover(
+              "trhh",
+              "Transition box height."
+            )
+          ),
+          value = rv_edges$trhh, min = 0, max = 1, step = .01
+        )
+      ),
+      column(
+        width = 3,
+        numericInput(
+          "trdigits",
+          label = tagList(
+            "Digits:",
+            helpPopover(
+              "trdigits",
+              "Number of digits past the decimal for transition weights in the transition box."
+            )
+          ),
+          value = rv_edges$trdigits, min = 1, max = 10, step = 1, width = "100%"
+        )
+      ),
+      column(
+        width = 3,
+        numericInput(
+          "boxtextsize",
+          label = tagList(
+            "Text size:",
+            helpPopover(
+              "boxtextsize",
+              "Transition text size."
+            )
+          ),
+          value = rv_edges$boxtextsize, min = 1, max = 20, step = 1
+        )
       )
-    ), rv_edges$offset, 0.01, 1, 0.01))),
-
+    ),
+    h5("Edge layout", style = "margin-top: 1rem;"),
+    hr(),
     fluidRow(
       column(
-        width = 12,
-        sliderInput("trprop", label = tagList(
-          "Box Position:",
-          helpPopover(
-            "trprop",
-            "Transition box's position proportional to edge length (relative to the edge starting point), value can be set between 0 and 1"
-          )
-        ), min = .05, max = .95, value = rv_edges$trprop, step = .01, width = "100%"))
+        width = 4,
+        numericInput(
+          "arrowsize",
+          label = tagList(
+            "Arrow size:",
+            helpPopover(
+              "arrowsize",
+              "Size of arrowhead for transition arrows."
+            )
+          ),
+          value = rv_edges$arrowsize, min = .005, max = .6, step = .005
+        )
+      ),
+      column(
+        width = 4,
+        numericInput(
+          "offset",
+          label = tagList(
+            "Offset:",
+            helpPopover(
+              "offset",
+              "Rotational offset in radians for transition edges,
+            can control space between neighbor edges."
+            )
+          ), value = rv_edges$offset, min = 0.01, max = 1, step = 0.01
+        )
+      ),
+      column(
+        width = 4,
+        numericInput(
+          "trprop",
+          label = tagList(
+            "Box position:",
+            helpPopover(
+              "trprop",
+              "Transition box's position proportional to edge length
+            (relative to the edge starting point), value can be set between 0 and 1."
+            )
+          ), value = rv_edges$trprop, min = 0, max = 1, step = 0.01, width = "100%"
+        )
+      )
     ),
+    easyClose = FALSE,
+    footer = tagList(
+      actionButton("btn_edge_settings_save", label = "Save Settings", class = "btn-primary", icon = icon("save")),
+      modalButton("Cancel")
+    )
+  ))
+})
 
-  easyClose = FALSE,
-  footer = tagList(
-    actionButton("btn_edge_settings_save", label = "Save Settings", class = "btn-primary", icon = icon("save")),
-    modalButton("Cancel")
-  )
-    ))
-  })
-
-  observeEvent(input$btn_edge_settings_save, {
-    rv_edges$trhw <- input$trhw
-    rv_edges$trhh <- input$trhh
-    rv_edges$trdigits <- input$trdigits
-    rv_edges$boxtextsize <- input$boxtextsize
-    rv_edges$trprop <- input$trprop
-    rv_edges$arrowsize <- input$arrowsize
-    rv_edges$offset <- input$offset
-    removeModal()
-  })
-
-
-
-
+observeEvent(input$btn_edge_settings_save, {
+  rv_edges$trhw <- input$trhw
+  rv_edges$trhh <- input$trhh
+  rv_edges$trdigits <- input$trdigits
+  rv_edges$boxtextsize <- input$boxtextsize
+  rv_edges$trprop <- input$trprop
+  rv_edges$arrowsize <- input$arrowsize
+  rv_edges$offset <- input$offset
+  removeModal()
+})

--- a/server/display-settings.R
+++ b/server/display-settings.R
@@ -89,6 +89,7 @@ observeEvent(input$btn_node_setting_modal, {
                   Use Unicode characters for Greek letters, for example, \\u03b1 for alpha.
                   Click the second icon for a more comprehensive character list."
             ),
+            HTML('&nbsp;'),
             helpLink("https://en.wikipedia.org/wiki/List_of_Unicode_characters")
           ),
           value = rv_nodes$wchar, width = "100%"

--- a/templates/call-hgraph.R
+++ b/templates/call-hgraph.R
@@ -5,7 +5,7 @@ h <- hGraph(
   nameHypotheses  = c(<%=paste0("\"", paste0(input$hypothesesMatrix[,"Name"], collapse = "\", \""), "\"")%>),
   alphaHypotheses = c(<%=paste0(as.numeric(input$hypothesesMatrix[,"Alpha"]), collapse = ", ")%>),
   m               = matrix(c(<%=paste0(c(df2graph(namesH = input$hypothesesMatrix[,1], df = data.frame(input$trwtMatrix)[(data.frame(input$trwtMatrix)[,1] %in% input$hypothesesMatrix[,1]) & (data.frame(input$trwtMatrix)[,2] %in% input$hypothesesMatrix[,1]),])), collapse = ", ")%>), nrow = <%=nrow(input$hypothesesMatrix)%>),
-  fill            = factor(c(<%=paste0("\"", paste0(input$hypothesesMatrix[,"Group"], collapse = "\", \""), "\"")%>),levels=unique(c(<%=paste0("\"", paste0(input$hypothesesMatrix[,"Group"], collapse = "\", \""), "\"")%>))),
+  fill            = factor(c(<%=paste0("\"", paste0(input$hypothesesMatrix[,"Group"], collapse = "\", \""), "\"")%>), levels = unique(c(<%=paste0("\"", paste0(input$hypothesesMatrix[,"Group"], collapse = "\", \""), "\"")%>))),
   palette         = c(<%=paste0("\"", paste0(hgraph_palette(pal_name = rv_nodes$pal_name, n = length(unique(input$hypothesesMatrix[,"Group"])), alpha = rv_nodes$pal_alpha), collapse = "\", \""), "\"")%>),
   labels          = c(<%=paste0("\"", paste0(unique(input$hypothesesMatrix[,"Group"]), collapse = "\", \""), "\"")%>),
   legend.name     = <%=paste0("\"", input$legend.name, "\"")%>,

--- a/ui/tabset-main.R
+++ b/ui/tabset-main.R
@@ -6,7 +6,7 @@ headingPanel(
       plotOutput("thePlot"),
       br(),
       hr(),
-      p("Right click the above graph, then select ", em("Copy image "), "or ", em("Save image as... "), "to copy or download it."),
+      p("To copy or download plot:", "right click the plot, select ", em("Copy image "), "or ", em("Save image as... ")),
     ),
     tabPanel(
       "Code",

--- a/ui/tabset-sidebar.R
+++ b/ui/tabset-sidebar.R
@@ -15,6 +15,7 @@ headingPanel(
             special characters. Click the second icon for a more comprehensive character list.
             Use `\\n` to add a line break. See `?Quotes` for details."
           ),
+          HTML('&nbsp;'),
           helpLink("https://en.wikipedia.org/wiki/List_of_Unicode_characters")
         ),
         value = as.matrix(data.frame(cbind(

--- a/ui/tabset-sidebar.R
+++ b/ui/tabset-sidebar.R
@@ -2,19 +2,20 @@ headingPanel(
   "Inputs",
   tabsetPanel(
     type = "tabs",
-
-    # Hypotheses Tab -----
-
     tabPanel(
       "Hypotheses",
-      matrixInput("hypothesesMatrix",
+      matrixInput(
+        "hypothesesMatrix",
         label = tagList(
-          "Set Hypotheses",
+          "Set hypotheses:",
           helpPopover(
-            "Hypotheses Matrix",
+            "Hypotheses matrix",
             "\"Name\" and \"Group\" need text input, \"Alpha\" needs numeric input.
-            The text inputs support Unicode escape sequence, like `\\uABCD` for a special symbol and `\\n` for adding a line break. See `?Quotes` for details."
-          )
+            The text inputs support Unicode escape sequence like `\\uABCD` for
+            special characters. Click the second icon for a more comprehensive character list.
+            Use `\\n` to add a line break. See `?Quotes` for details."
+          ),
+          helpLink("https://en.wikipedia.org/wiki/List_of_Unicode_characters")
         ),
         value = as.matrix(data.frame(cbind(
           Name = paste0("H", 1:4),
@@ -26,25 +27,28 @@ headingPanel(
         cols = list(names = TRUE, editableNames = FALSE, extend = FALSE)
       ),
       matrixButtonGroup("hypothesesMatrix"),
-
       br(),
-
-      matrixInput("nodeposMatrix",
-                  label = tagList(
-                    "Customize Node Position",
-                    helpPopover(
-                      "Node Position Matrix",
-                      "The \"Hypotheses\" text inputs support Unicode escape sequence, like `\\uABCD` for a special symbol and `\\n` for adding a line break. See `?Quotes` for details.
-                  The \"x\", \"y\" numeric inputs are coordinates for the relative position of the hypothesis ellipses."
-                    )
-                  ),
-                  value = as.matrix(data.frame(cbind(Hypothesis = paste0("H", 1:4),
-                                                     x = c(-1, 1, 1, -1),
-                                                     y = c(1, 1, -1, -1)
-                  ))),
-                  class = "character",
-                  rows = list(names = FALSE, editableNames = FALSE, extend = FALSE),
-                  cols = list(names = TRUE, editableNames = FALSE, extend = FALSE)
+      matrixInput(
+        "nodeposMatrix",
+        label = tagList(
+          "Customize node position:",
+          helpPopover(
+            "Node position matrix",
+            "The \"Hypotheses\" text inputs support Unicode escape sequence,
+            like `\\uABCD` for a special symbol and `\\n` for adding a line break.
+            See `?Quotes` for details.
+            The \"x\", \"y\" numeric inputs are coordinates for the
+            relative position of the hypothesis ellipses."
+          )
+        ),
+        value = as.matrix(data.frame(cbind(
+          Hypothesis = paste0("H", 1:4),
+          x = c(-1, 1, 1, -1),
+          y = c(1, 1, -1, -1)
+        ))),
+        class = "character",
+        rows = list(names = FALSE, editableNames = FALSE, extend = FALSE),
+        cols = list(names = TRUE, editableNames = FALSE, extend = FALSE)
       ),
       actionButton(
         "btn_nodeposMatrix_reset_init",
@@ -53,45 +57,68 @@ headingPanel(
         width = "100%",
         class = "btn btn-block btn-outline-primary"
       ),
-
       br(),
       br(),
-
-      selectInput("legendPosition",
-                  label = tagList(
-                    "Legend Position",
-                    helpPopover(
-                      "legend.position",
-                      "choosing \"none\" is to turn off legend."
-                    )
-                  ),
-                  choices = c("none", "left", "right", "bottom", "top"), selected = "bottom", multiple = FALSE),
+      selectInput(
+        "legendPosition",
+        label = tagList(
+          "Legend position:",
+          helpPopover(
+            "legend.position",
+            "Select \"none\" to turn off legend."
+          )
+        ),
+        choices = c("none", "left", "right", "bottom", "top"),
+        selected = "bottom",
+        multiple = FALSE
+      ),
       conditionalPanel(
         condition = "input.legendPosition != 'none'",
-        textInput("legend.name", label = "Legend Name", value = "Group Name"),
-        numericInput("legend.textsize", "Legend Text Size", 20, 6, 50, 1)
-
+        textInput(
+          "legend.name",
+          label = tagList(
+            "Legend title:",
+            helpPopover(
+              "legend.name",
+              "Text for legend title"
+            )
+          ),
+          value = "Group Name"
+        ),
+        numericInput(
+          "legend.textsize",
+          label = tagList(
+            "Legend text size:",
+            helpPopover(
+              "legend.textsize",
+              "Legend text size"
+            )
+          ),
+          value = 20, min = 6, max = 50, step = 1
+        )
+      ),
+      hr(),
+      actionButton(
+        "btn_node_setting_modal",
+        label = "More Node Settings",
+        class = "btn btn-outline-primary",
+        icon = icon("cog"),
+        width = "100%"
+      )
     ),
-
-    hr(),
-
-    actionButton("btn_node_setting_modal", label = "More Node Settings", class = "btn btn-outline-primary", icon = icon("cog"), width =  "100%")
-    ), # end Hypotheses Tab
-
-    # Transitions Tab -----
-
     tabPanel(
       "Transitions",
       matrixInput("trwtMatrix",
-          label = tagList(
-            "Set Transition Weights",
-            helpPopover(
-              "Transition Weights Matrix",
-              "\"From\" and \"To\" need text input, shoud be corresponded to hypotheses names, \"Weight\" needs numeric input, should be between 0 and 1.
-              Transitions between non-existing hypotheses will not influence graph output."
-            )
-          ),
-          value = as.matrix(data.frame(cbind(
+        label = tagList(
+          "Set transition weights:",
+          helpPopover(
+            "Transition weights matrix",
+            "\"From\" and \"To\" need text input, shoud match hypotheses names,
+            \"Weight\" needs numeric input, should be between 0 and 1.
+              Transitions between non-existing hypotheses will not affect graph output."
+          )
+        ),
+        value = as.matrix(data.frame(cbind(
           From = paste0("H", c(1, 2, 3, 4)),
           To = paste0("H", c(2, 3, 4, 1)),
           Weight = rep(1, 4)
@@ -102,11 +129,13 @@ headingPanel(
       ),
       matrixButtonGroup("trwtMatrix"),
       hr(),
-      actionButton("btn_edge_setting_modal", label = "More Edge Settings", class = "btn btn-outline-primary", icon = icon("cog"), width =  "100%")
-
-    ) # end Transitions Tab
-
-    # Format Tab -----
-
-  ) # end tabsetPanel (maintabs)
+      actionButton(
+        "btn_edge_setting_modal",
+        label = "More Edge Settings",
+        class = "btn btn-outline-primary",
+        icon = icon("cog"),
+        width = "100%"
+      )
+    )
+  )
 )

--- a/www/css/custom.css
+++ b/www/css/custom.css
@@ -43,6 +43,7 @@ hr {
 /* popover icon */
 a.help-popover {
     color: #6c757d;
+    text-decoration: none;
 }
 
 a.help-popover:hover,


### PR DESCRIPTION
This PR:

- Adds popover help for all inputs.
- Adds a Unicode character list link for two inputs that needed the hint the most.
- Replaces the two slider inputs with numeric inputs for better consistency and accessibility (the current sliderInput control in shiny is inaccessible for keyboard or screen reader users).
- Improves a few minor UI details for better consistency.