### PR TITLE
use stringi's function to sort mixture type strings,

### DIFF
--- a/server/show-example.R
+++ b/server/show-example.R
@@ -11,7 +11,7 @@ observeEvent(input$btn_hgraph_example_modal, {
       choices = gsub(".rds", "",
                 gsub("_", " ",
                 gsub("-", ": ",
-                gsub("\\+", ", ", gtools::mixedsort(list.files("data/")))))),
+                gsub("\\+", ", ", stringi::stri_sort(list.files("data/"), numeric = TRUE))))),
       width = "100%"
     ),
 


### PR DESCRIPTION
Hotfix: Thanks @nanxstats suggestion, using `stringi::stri_sort()` to reduce another package dependency 