### PR TITLE
grid.arrange to wrap graph with the flexible position of title

### DIFF
--- a/server/graph-output.R
+++ b/server/graph-output.R
@@ -13,7 +13,7 @@ plotInput <- reactive({
   m <- df2graph(namesH = input$hypothesesMatrix[,1], df = transitions)
 
 
-  gMCPmini::hGraph(
+  h <- gMCPmini::hGraph(
     nHypotheses = nrow(input$hypothesesMatrix),
     nameHypotheses = stringi::stri_unescape_unicode(input$hypothesesMatrix[,"Name"]),
     alphaHypotheses = sapply(input$hypothesesMatrix[,"Alpha"], arithmetic_to_numeric),
@@ -41,6 +41,8 @@ plotInput <- reactive({
     wchar = stringi::stri_unescape_unicode(rv_nodes$wchar)
   )
 
+  ifelse(input$titlePosition=='top',grid.arrange(h, top=textGrob(input$title.name, gp=gpar(fontsize=input$title.textsize))),
+         grid.arrange(h, bottom=textGrob(input$title.name, gp=gpar(fontsize=input$title.textsize))))
 
 })
 

--- a/templates/call-hgraph.R
+++ b/templates/call-hgraph.R
@@ -27,4 +27,4 @@ h <- hGraph(
   wchar           = <%=paste0("\"", rv_nodes$wchar, "\"")%>
 )
 
-plot(h)
+grid.arrange(h, <%=input$titlePosition%>=textGrob(<%=paste0("\"", input$title.name, "\"")%>, gp=gpar(fontsize=<%=input$title.textsize%>)))

--- a/ui/tabset-sidebar.R
+++ b/ui/tabset-sidebar.R
@@ -96,6 +96,48 @@ headingPanel(
           value = 20, min = 6, max = 50, step = 1
         )
       ),
+
+      br(),
+      selectInput(
+        "titlePosition",
+        label = tagList(
+          "Title position:",
+          helpPopover(
+            "title.position",
+            "Select \"none\" to turn off title"
+          )
+        ),
+        choices = c("none", "bottom", "top"),
+        selected = "none",
+        multiple = FALSE
+      ),
+      conditionalPanel(
+        condition = "input.titlePosition != 'none'",
+        textInput(
+          "title.name",
+          label = tagList(
+            "Title:",
+            helpPopover(
+              "title.name",
+              "Text for title"
+            )
+          ),
+          value = ""
+        ),
+        numericInput(
+          "title.textsize",
+          label = tagList(
+            "Title text size:",
+            helpPopover(
+              "title.textsize",
+              "Title text size"
+            )
+          ),
+          value = 30, min = 6, max = 50, step = 1
+        )
+      ),
+
+
       hr(),
       actionButton(
         "btn_node_setting_modal",


### PR DESCRIPTION
use grid::grid.arrange instead of ggtitle to have flexibility of title position.
Current version is directly adding title section after legend. Please review to see if it is okay and whether we want to create 3rd tab. 