### PR TITLE
Add save plot button

### DIFF
--- a/server/graph-save.R
+++ b/server/graph-save.R
@@ -1,0 +1,110 @@
+observeEvent(input$btn_modal_save_png, {
+  showModal(modalDialog(
+    title = "Dowload Plot",
+    textInputAddonRight(
+      "filename_png",
+      label = tagList(
+        "File name:",
+        helpPopover(
+          "filename",
+          "PNG file name."
+        )
+      ),
+      value = "hgraph",
+      addon = ".png",
+      width = "100%"
+    ),
+    fluidRow(
+      column(
+        6,
+        textInputAddonRight(
+          "width_png",
+          label = tagList(
+            "Width:",
+            helpPopover(
+              "width",
+              "Width of the PNG."
+            )
+          ),
+          value = 1294, addon = "px", width = "100%"
+        )
+      ),
+      column(
+        6,
+        textInputAddonRight(
+          "height_png",
+          label = tagList(
+            "Height:",
+            helpPopover(
+              "height",
+              "Height of the PNG."
+            )
+          ),
+          value = 800, addon = "px", width = "100%"
+        )
+      )
+    ),
+    fluidRow(
+      column(
+        6,
+        numericInput(
+          "dpi_png",
+          label = tagList(
+            "DPI:",
+            helpPopover(
+              "DPI",
+              "Resolution of the PNG."
+            )
+          ),
+          value = 72, min = 72, max = 600, width = "100%"
+        )
+      ),
+      column(
+        6,
+        numericInput(
+          "scale_png",
+          label = tagList(
+            "Scaling factor:",
+            helpPopover(
+              "scaling",
+              "Multiplicative scaling factor for line width and text size.
+              Useful for getting the right dimensions at the resolution you need.
+              For example, if you need a plot at 3000x2000 px to fit into a layout,
+              but it appears too small, you can increase this setting to
+              make everything appear bigger at the same resolution."
+            )
+          ),
+          value = 2, min = 1, max = 10, width = "100%"
+        )
+      )
+    ),
+    easyClose = TRUE,
+    footer = tagList(
+      downloadButton("btn_save_png", label = "Download Plot", class = "btn-primary", icon = icon("download")),
+      modalButton("Cancel")
+    )
+  ))
+})
+
+output$btn_save_png <- downloadHandler(
+  filename = function() {
+    x <- input$filename_png
+    # sanitize from input
+    fn0 <- if (x == "") "hgraph" else sanitize_filename(x)
+    # sanitize again
+    fn <- if (fn0 == "") "hgraph" else fn0
+    paste0(fn, ".png")
+  },
+  content = function(con) {
+    ragg::agg_png(
+      filename = con,
+      width = min(8000, as.numeric(input$width_png)),
+      height = min(8000, as.numeric(input$height_png)),
+      units = "px",
+      res = input$dpi_png,
+      scaling = input$scale_png
+    )
+    print(plotInput())
+    dev.off()
+  }
+)

--- a/server/main.R
+++ b/server/main.R
@@ -12,3 +12,6 @@ source("server/display-settings.R", local = TRUE)$value
 
 # Example graphs button
 source("server/show-example.R", local = TRUE)$value
+
+# Save plot button
+source("server/graph-save.R", local = TRUE)$value

--- a/ui/tabset-main.R
+++ b/ui/tabset-main.R
@@ -6,12 +6,12 @@ headingPanel(
       plotOutput("thePlot"),
       br(),
       hr(),
-      p("To copy or download plot:", "right click the plot, select ", em("Copy image "), "or ", em("Save image as... ")),
+      actionButton("btn_modal_save_png", label = "Dowload Plot", class = "btn btn-outline-primary", icon = icon("download"))
     ),
     tabPanel(
       "Code",
-      downloadButton("downloadCode", label = "Download R Code", class = "btn btn-outline-primary", style = "margin-bottom: 1rem;"),
-      rcodeOutput("changingCode")
+      rcodeOutput("changingCode"),
+      downloadButton("downloadCode", label = "Download R Code", class = "btn btn-outline-primary")
     )
   )
 )


### PR DESCRIPTION
This PR added a "save plot" button under the plot output, which triggers a popup modal.

Hopefully this is useful for scenarios where particular figure specifications (resolution, DPI) is required and the user prefers saving the hassle of going to the code, figuring out `ggplot2::ggsave()` or `ragg::agg_png()`, etc.

It's a bit challenging to come up with a set of sensible default values for the popup inputs, but eventually the current set seems working ok with all the examples.