### PR TITLE
Add missing documentation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gMCPShiny
 Title: Shiny App for Graphical Multiplicity
-Version: 2022.12.0
+Version: 2023.5.0
 Authors@R: c(
     person("Yalin", "Zhu", email = "yalin.zhu@merck.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3830-8660")),
@@ -52,4 +52,4 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3

--- a/R/adaptive-palette.R
+++ b/R/adaptive-palette.R
@@ -1,10 +1,10 @@
-#' Adaptive palette (discrete)
+#' Adaptive color palette (discrete)
 #'
 #' Create a discrete palette that will use the first `n` colors from
 #' the supplied color values when the palette has enough colors.
 #' Otherwise, use an interpolated color palette.
 #'
-#' @param values Color values.
+#' @param values A vector of color values.
 #'
 #' @importFrom grDevices colorRampPalette
 #'
@@ -22,20 +22,16 @@ pal_ramp <- function(values) {
 
 #' Adaptive color palette generator
 #'
-#' Adaptive color palette generator for ggsci color palettes using `pal_ramp()`.
+#' Adaptive color palette generator using `pal_ramp()`.
 #'
 #' @param raw_cols Character vector of color hex values.
 #' @param alpha Transparency level, a real number in (0, 1].
-#'
-#' @details See `names(ggsci:::ggsci_db)` for all color palette names in ggsci.
-#' See `names(ggsci:::ggsci_db$"pal")` for available palette types under
-#' the palette `pal`.
 #'
 #' @importFrom grDevices col2rgb rgb
 #'
 #' @noRd
 pal_adaptive <- function(raw_cols, alpha = 1) {
-  if (alpha > 1L | alpha <= 0L) stop("alpha must be in (0, 1]")
+  if (alpha > 1L || alpha <= 0L) stop("alpha must be in (0, 1]")
   raw_cols_rgb <- col2rgb(raw_cols)
   alpha_cols <- rgb(
     raw_cols_rgb[1L, ], raw_cols_rgb[2L, ], raw_cols_rgb[3L, ],
@@ -81,27 +77,30 @@ hgraph_pal_hex <- list(
 
 #' Adaptive color palette generator for hGraph
 #'
-#' Adaptive color palette generator for hGraph using `pal_adaptive()` and `pal_ramp()`.
+#' Adaptive color palette generator for hGraph using
+#' `pal_adaptive()` and `pal_ramp()`.
 #'
-#' @param pal_name Color palette name
-#' @param n How many different colors for the selected color palette
+#' @param pal_name Color palette name.
+#' @param n How many different colors for the selected color palette?
 #' @param alpha Transparency level, a real number in (0, 1].
 #'
-#' @return TBA
+#' @return A vector of color hex values.
 #'
-#' @export hgraph_palette
+#' @export
 #'
 #' @examples
-#' NULL
-hgraph_palette <- function(pal_name = c(
-                             "gray",
-                             "Okabe-Ito",
-                             "d3.category10",
-                             "d3.category20",
-                             "d3.category20b",
-                             "d3.category20c",
-                             "Teal"
-                           ), n, alpha = 1) {
+#' hgraph_palette("gray", n = 10)
+#' hgraph_palette("Okabe-Ito", n = 15)
+hgraph_palette <- function(
+    pal_name = c(
+      "gray",
+      "Okabe-Ito",
+      "d3.category10",
+      "d3.category20",
+      "d3.category20b",
+      "d3.category20c",
+      "Teal"
+    ), n, alpha = 1) {
   pal_name <- match.arg(pal_name)
 
   if (pal_name == "gray") {

--- a/R/arith2numeric.R
+++ b/R/arith2numeric.R
@@ -1,10 +1,10 @@
 #' Convert arithmetic (character) format to numeric
 #'
-#' @param x character string containing arithmetic operators
+#' @param x Character string containing arithmetic operators.
 #'
-#' @return TBA
+#' @return The numeric value from evaluating the arithmetic expression.
 #'
-#' @export arithmetic_to_numeric
+#' @export
 #'
 #' @examples
 #' # Return numeric values
@@ -20,9 +20,11 @@ arithmetic_to_numeric <- function(x) {
   if (inherits(w_numeric, "try-error")) NA else w_numeric
 }
 
-#' Evaluate evaluate arithmetic expressions (in character string format) safely
+#' Evaluate arithmetic expressions (in character string format) safely
 #'
-#' @param x Must be a character string
+#' @param x A character string.
+#'
+#' @noRd
 #'
 #' @examples
 #' # Can't access variables outside of that environment
@@ -37,8 +39,6 @@ arithmetic_to_numeric <- function(x) {
 #'
 #' # Can't return non-numeric values
 #' safe_eval_str('"a"')
-#'
-#' @noRd
 safe_eval_str <- function(x) {
   if (!is.character(x)) stop("`x` must be a character.")
   res <- eval(parse(text = x), envir = env_safe())
@@ -46,9 +46,13 @@ safe_eval_str <- function(x) {
   res
 }
 
-# Create a calculator environment to evaluate arithmetic expressions safely
-# Modified from https://stackoverflow.com/a/18391779
+#' Create a calculator environment to evaluate arithmetic expressions safely
+#'
+#' Modified from <https://stackoverflow.com/a/18391779>.
+#'
 #' @importFrom methods getGroupMembers
+#'
+#' @noRd
 env_safe <- function() {
   safe_f <- c(getGroupMembers("Math"), getGroupMembers("Arith"), "(", "pi")
   safe_env <- new.env(parent = emptyenv())

--- a/R/card.R
+++ b/R/card.R
@@ -1,18 +1,20 @@
 #' Card with header
 #'
-#' Card with header
+#' Card with header (Bootstrap 5).
 #'
-#' @param title TBA
-#' @param ... TBA
+#' @param title Card title.
+#' @param ... List of elements to include in the body of the card.
 #'
-#' @return TBA
+#' @return Card element with header and body.
 #'
 #' @importFrom htmltools tags div
 #'
-#' @export headerCard
+#' @export
 #'
 #' @examples
-#' NULL
+#' if (interactive()) {
+#'   headerCard("Card title", "Card body")
+#' }
 headerCard <- function(title, ...) {
   div(
     class = "card",

--- a/R/df2graph.R
+++ b/R/df2graph.R
@@ -1,20 +1,28 @@
-#' df2graph
+#' Convert transitions data frame into an hgraph matrix
 #'
-#' Description TBA
+#' Convert transitions data frame into an hgraph matrix,
+#' given all the hypothesis names, with transition weights evaluated.
 #'
-#' @param namesH TBA
-#' @param df TBA
+#' @param namesH Hypothesis names.
+#' @param df Input data frame of transitions.
 #'
-#' @return TBA
+#' @return An hgraph matrix.
 #'
-#' @export df2graph
+#' @export
 #'
 #' @examples
-#' NULL
+#' df2graph(
+#'   namesH = paste0("H", 1:6),
+#'   df = data.frame(
+#'     From = paste0("H", 1:4),
+#'     To = paste0("H", c(2:4, 1)),
+#'     Weight = rep(1, 4)
+#'   )
+#' )
 df2graph <- function(namesH, df) {
   # Check to make sure the column names are present
   if (!any(names(df) %in% c("From", "To", "Weight"))) {
-    print("Must have three columns in the input data frame: 'From', 'To', and 'Weight'")
+    print("Must have three columns in the input data frame: 'From', 'To', and 'Weight'.")
   }
   dim <- length(namesH)
   m <- matrix(rep(0, dim^2), nrow = dim)
@@ -22,7 +30,7 @@ df2graph <- function(namesH, df) {
   for (i in 1:nrow(df)) {
     row.index <- which(namesH %in% df$From[i])
     col.index <- which(namesH %in% df$To[i])
-    m[row.index, col.index] <-  arithmetic_to_numeric(df$Weight[i])
+    m[row.index, col.index] <- arithmetic_to_numeric(df$Weight[i])
   }
   m
 }

--- a/R/help-popover.R
+++ b/R/help-popover.R
@@ -1,19 +1,22 @@
 #' Help popovers
 #'
-#' Help popovers (with question mark icon)
+#' Help popovers with question mark icon (Bootstrap 5).
 #'
-#' @param title TBA
-#' @param content TBA
+#' @param title Title of the popover.
+#' @param content Content of the popover.
 #'
-#' @return TBA
+#' @return Popover element.
 #'
 #' @importFrom htmltools tags tagList
 #' @importFrom shiny icon
 #'
-#' @export helpPopover
+#' @export
 #'
 #' @examples
-#' NULL
+#' helpPopover(
+#'   "digits",
+#'   "Number of digits past the decimal."
+#' )
 helpPopover <- function(title, content) {
   tagList(
     includePopoverJs(),
@@ -49,17 +52,17 @@ includePopoverJs <- function() singleton(list(injectPopoverHandler()))
 #'
 #' Help link with an icon and opens in a new window or tab.
 #'
-#' @param href TBA
+#' @param href URL to open.
 #'
-#' @return TBA
+#' @return Link element.
 #'
 #' @importFrom htmltools tags
 #' @importFrom shiny icon
 #'
-#' @export helpLink
+#' @export
 #'
 #' @examples
-#' NULL
+#' helpLink("https://en.wikipedia.org/wiki/List_of_Unicode_characters")
 helpLink <- function(href) {
   tags$a(
     href = href,

--- a/R/input-file-button.R
+++ b/R/input-file-button.R
@@ -9,7 +9,7 @@
 #' @importFrom htmltools tags span
 #' @importFrom shiny validateCssUnit restoreInput
 #'
-#' @export fileButtonInput
+#' @export
 #'
 #' @examples
 #' fileButtonInput(

--- a/R/input-file-button.R
+++ b/R/input-file-button.R
@@ -1,10 +1,10 @@
 #' File input button
 #'
-#' File input but with only the button
+#' File input but with only the button.
 #'
 #' @inheritParams shiny::fileInput
 #'
-#' @return TBA
+#' @return Button for file input.
 #'
 #' @importFrom htmltools tags span
 #' @importFrom shiny validateCssUnit restoreInput
@@ -12,9 +12,22 @@
 #' @export fileButtonInput
 #'
 #' @examples
-#' NULL
-fileButtonInput <- function(inputId, label, multiple = FALSE, accept = NULL, width = NULL,
-                            buttonLabel = "Browse...", placeholder = "No file selected") {
+#' fileButtonInput(
+#'   "restore",
+#'   label = NULL,
+#'   buttonLabel = "Restore",
+#'   multiple = FALSE,
+#'   accept = ".rds",
+#'   width = "50%"
+#' )
+fileButtonInput <- function(
+    inputId,
+    label,
+    multiple = FALSE,
+    accept = NULL,
+    width = NULL,
+    buttonLabel = "Browse...",
+    placeholder = "No file selected") {
   restoredValue <- restoreInput(id = inputId, default = NULL)
   if (!is.null(restoredValue) && !is.data.frame(restoredValue)) {
     warning("Restored value for ", inputId, " has incorrect format.")
@@ -58,10 +71,11 @@ fileButtonInput <- function(inputId, label, multiple = FALSE, accept = NULL, wid
 }
 
 # Copy of shiny:::toJSON()
-toJSON_ <- function(x, ..., dataframe = "columns", null = "null", na = "null",
-                    auto_unbox = TRUE, digits = getOption("shiny.json.digits", 16),
-                    use_signif = TRUE, force = TRUE, POSIXt = "ISO8601", UTC = TRUE,
-                    rownames = FALSE, keep_vec_names = TRUE, strict_atomic = TRUE) {
+toJSON_ <- function(
+    x, ..., dataframe = "columns", null = "null", na = "null",
+    auto_unbox = TRUE, digits = getOption("shiny.json.digits", 16),
+    use_signif = TRUE, force = TRUE, POSIXt = "ISO8601", UTC = TRUE,
+    rownames = FALSE, keep_vec_names = TRUE, strict_atomic = TRUE) {
   if (strict_atomic) {
     x <- I(x)
   }

--- a/R/input-matrix-buttons.R
+++ b/R/input-matrix-buttons.R
@@ -1,17 +1,17 @@
 #' Matrix buttons
 #'
-#' Buttons to add/delete rows and reset a matrix input
+#' Buttons to add/delete rows and reset a matrix input.
 #'
-#' @param inputId TBA
+#' @param inputId ID of the matrix input.
 #'
-#' @return TBA
+#' @return A matrix button group.
 #'
 #' @importFrom shiny fluidRow column actionButton icon
 #'
-#' @export matrixButtonGroup
+#' @export
 #'
 #' @examples
-#' NULL
+#' matrixButtonGroup("matrix")
 matrixButtonGroup <- function(inputId) {
   fluidRow(
     column(
@@ -49,18 +49,16 @@ matrixButtonGroup <- function(inputId) {
 
 #' @rdname matrixButtonGroup
 #'
-#' @param x TBA
+#' @param x Name of the matrix input to add a row to or delete a row from.
 #'
-#' @export addMatrixRow
+#' @export
 addMatrixRow <- function(x) {
   rbind(x, rep(NA, ncol(x)))
 }
 
 #' @rdname matrixButtonGroup
 #'
-#' @param x TBA
-#'
-#' @export delMatrixRow
+#' @export
 delMatrixRow <- function(x) {
   if (nrow(x) == 1L) {
     return(x)

--- a/R/input-text-addon.R
+++ b/R/input-text-addon.R
@@ -13,7 +13,7 @@
 #' @importFrom htmltools tags span
 #' @importFrom shiny validateCssUnit restoreInput
 #'
-#' @export textInputAddonRight
+#' @export
 #'
 #' @examples
 #' textInputAddonRight(

--- a/R/input-text-addon.R
+++ b/R/input-text-addon.R
@@ -1,12 +1,14 @@
 #' Text input addon
 #'
 #' Text input with addon on the right side.
-#' From <https://getbootstrap.com/docs/5.2/forms/input-group/>.
 #'
 #' @inheritParams shiny::textInput
-#' @param addon Addon text
+#' @param addon Addon text.
 #'
-#' @return TBA
+#' @return Text input with addon on the right side.
+#'
+#' @references
+#' <https://getbootstrap.com/docs/5.3/forms/input-group/>
 #'
 #' @importFrom htmltools tags span
 #' @importFrom shiny validateCssUnit restoreInput
@@ -14,7 +16,13 @@
 #' @export textInputAddonRight
 #'
 #' @examples
-#' NULL
+#' textInputAddonRight(
+#'   "filename",
+#'   label = "Name of the report:",
+#'   value = "gMCPShiny",
+#'   addon = ".Rmd",
+#'   width = "100%"
+#' )
 textInputAddonRight <- function(inputId, label, value = "", width = NULL, placeholder = NULL, addon = NULL) {
   value <- restoreInput(id = inputId, default = value)
   div(

--- a/R/navbar-fluid-page.R
+++ b/R/navbar-fluid-page.R
@@ -1,41 +1,49 @@
 #' Create a page with a top level navigation bar within a fluid container
 #'
-#' Slightly modified from shiny::navbarPage to support:
-#' * navbar inside a fluid container instead of full width
-#' * brand image before title.
+#' Slightly modified from [shiny::navbarPage()] to support:
+#' - Navbar inside a fluid container instead of full width.
+#' - Brand image before title.
 #'
 #' @inheritParams shiny::navbarPage
-#' @param brand_image TBA
-#' @param brand_image_width TBA
-#' @param brand_image_height TBA
+#' @param brand_image Path to the brand image.
+#' @param brand_image_width Width of the brand image in pixels.
+#' @param brand_image_height Height of the brand image in pixels.
 #'
-#' @return TBA
+#' @return A page with a top level navigation bar within a fluid container.
 #'
-#' @export navbarFluidPage
+#' @export
 #'
 #' @examples
-#' NULL
+#' library(shiny)
 #'
+#' navbarFluidPage(
+#'   "App Title",
+#'   tabPanel("Plot"),
+#'   tabPanel("Summary"),
+#'   tabPanel("Table")
+#' )
+
 # shiny and bslib versions:
 # https://github.com/rstudio/shiny/tree/9389160af06b2f26d3746fa06c6ac0df8e76c8dd
 # https://github.com/rstudio/bslib/tree/888fbe064491692deb56fd90dc23455052e31073
-#'
-navbarFluidPage <- function(title,
-                            ...,
-                            id = NULL,
-                            selected = NULL,
-                            position = c("static-top", "fixed-top", "fixed-bottom"),
-                            header = NULL,
-                            footer = NULL,
-                            inverse = FALSE,
-                            collapsible = FALSE,
-                            fluid = TRUE,
-                            theme = NULL,
-                            windowTitle = NA,
-                            lang = NULL,
-                            brand_image,
-                            brand_image_width,
-                            brand_image_height) {
+
+navbarFluidPage <- function(
+    title,
+    ...,
+    id = NULL,
+    selected = NULL,
+    position = c("static-top", "fixed-top", "fixed-bottom"),
+    header = NULL,
+    footer = NULL,
+    inverse = FALSE,
+    collapsible = FALSE,
+    fluid = TRUE,
+    theme = NULL,
+    windowTitle = NA,
+    lang = NULL,
+    brand_image,
+    brand_image_width,
+    brand_image_height) {
   remove_first_class <- function(x) {
     class(x) <- class(x)[-1]
     x
@@ -71,17 +79,18 @@ find_characters <- function(x) {
 }
 
 #' @importFrom bslib bs_theme
-page_navbar <- function(..., title = NULL, id = NULL, selected = NULL,
-                        position = c("static-top", "fixed-top", "fixed-bottom"),
-                        header = NULL, footer = NULL,
-                        bg = NULL, inverse = "auto",
-                        collapsible = TRUE, fluid = TRUE,
-                        theme = bs_theme(),
-                        window_title = NA,
-                        lang = NULL,
-                        brand_image,
-                        brand_image_width,
-                        brand_image_height) {
+page_navbar <- function(
+    ..., title = NULL, id = NULL, selected = NULL,
+    position = c("static-top", "fixed-top", "fixed-bottom"),
+    header = NULL, footer = NULL,
+    bg = NULL, inverse = "auto",
+    collapsible = TRUE, fluid = TRUE,
+    theme = bs_theme(),
+    window_title = NA,
+    lang = NULL,
+    brand_image,
+    brand_image_width,
+    brand_image_height) {
   # https://github.com/rstudio/shiny/issues/2310
   if (!is.null(title) && isTRUE(is.na(window_title))) {
     window_title <- unlist(find_characters(title))
@@ -111,15 +120,16 @@ page_navbar <- function(..., title = NULL, id = NULL, selected = NULL,
 
 #' @importFrom htmltools css tagAppendAttributes
 #' @importFrom bslib bs_get_contrast
-navs_bar <- function(..., title = NULL, id = NULL, selected = NULL,
-                     # TODO: add sticky-top as well?
-                     position = c("static-top", "fixed-top", "fixed-bottom"),
-                     header = NULL, footer = NULL,
-                     bg = NULL, inverse = "auto",
-                     collapsible = TRUE, fluid = TRUE,
-                     brand_image,
-                     brand_image_width,
-                     brand_image_height) {
+navs_bar <- function(
+    ..., title = NULL, id = NULL, selected = NULL,
+    # TODO: add sticky-top as well?
+    position = c("static-top", "fixed-top", "fixed-bottom"),
+    header = NULL, footer = NULL,
+    bg = NULL, inverse = "auto",
+    collapsible = TRUE, fluid = TRUE,
+    brand_image,
+    brand_image_width,
+    brand_image_height) {
   if (identical(inverse, "auto")) {
     inverse <- TRUE
     if (!is.null(bg)) {
@@ -313,8 +323,9 @@ buildNavItem <- function(divTag, tabsetId, index) {
 # declared inside the buildTabset() function and it's been
 # refactored for clarity and reusability). Called internally
 # by buildTabset.
-buildTabItem <- function(index, tabsetId, foundSelected, tabs = NULL,
-                         divTag = NULL, textFilter = NULL) {
+buildTabItem <- function(
+    index, tabsetId, foundSelected, tabs = NULL,
+    divTag = NULL, textFilter = NULL) {
   divTag <- divTag %||% tabs[[index]]
 
   # Handles navlistPanel() headers and dropdown dividers
@@ -472,22 +483,23 @@ tag_has_class_ <- function(x, class) {
 #  (with minor modifications)
 # -----------------------------------------------------------------------
 #' @importFrom htmltools tagList tagAppendChild
-navbarPage_ <- function(title,
-                        ...,
-                        id = NULL,
-                        selected = NULL,
-                        position = c("static-top", "fixed-top", "fixed-bottom"),
-                        header = NULL,
-                        footer = NULL,
-                        inverse = FALSE,
-                        collapsible = FALSE,
-                        fluid = TRUE,
-                        theme = NULL,
-                        windowTitle = title,
-                        lang = NULL,
-                        brand_image,
-                        brand_image_width,
-                        brand_image_height) {
+navbarPage_ <- function(
+    title,
+    ...,
+    id = NULL,
+    selected = NULL,
+    position = c("static-top", "fixed-top", "fixed-bottom"),
+    header = NULL,
+    footer = NULL,
+    inverse = FALSE,
+    collapsible = FALSE,
+    fluid = TRUE,
+    theme = NULL,
+    windowTitle = title,
+    lang = NULL,
+    brand_image,
+    brand_image_width,
+    brand_image_height) {
   # alias title so we can avoid conflicts w/ title in withTags
   pageTitle <- title
 

--- a/R/output-rcode.R
+++ b/R/output-rcode.R
@@ -1,20 +1,54 @@
 #' Render R code with syntax highlighting
 #'
-#' Description TBA
+#' Renders R code with syntax highlighting using the highlight.js library.
 #'
 #' @inheritParams shiny::renderText
-#' @param outputArgs TBA
-#' @param delay TBA
+#' @param outputArgs List of additional arguments to pass to the
+#'   output function.
+#' @param delay Delay in milliseconds before syntax highlighting starts.
 #'
-#' @return TBA
+#' @return A render function similar to [shiny::renderText()].
 #'
 #' @importFrom shiny exprToFunction markRenderFunction
 #'
-#' @export renderRcode
+#' @export
 #'
 #' @examples
-#' NULL
-renderRcode <- function(expr, env = parent.frame(), quoted = FALSE, outputArgs = list(), delay = 100) {
+#' if (interactive()) {
+#'   library("shiny")
+#'
+#'   ui <- fluidPage(
+#'     fluidRow(
+#'       column(
+#'         4,
+#'         textAreaInput(
+#'           "rcode_in",
+#'           label = NULL,
+#'           width = "100%", height = "300px",
+#'           value = "library('shiny')\n\nset.seed(42)\nx <- runif(10)"
+#'         )
+#'       ),
+#'       column(
+#'         8,
+#'         rcodeOutput("rcode_out")
+#'       )
+#'     )
+#'   )
+#'
+#'   server <- function(input, output) {
+#'     output$rcode_out <- renderRcode({
+#'       htmltools::htmlEscape(input$rcode_in)
+#'     })
+#'   }
+#'
+#'   shinyApp(ui = ui, server = server)
+#' }
+renderRcode <- function(
+    expr,
+    env = parent.frame(),
+    quoted = FALSE,
+    outputArgs = list(),
+    delay = 100) {
   func <- exprToFunction(expr, env, quoted)
   renderFunc <- function(shinysession, name, ...) {
     value <- func()
@@ -33,7 +67,7 @@ renderRcode <- function(expr, env = parent.frame(), quoted = FALSE, outputArgs =
 #' @importFrom htmltools tagList
 #' @importFrom shiny uiOutput
 #'
-#' @export rcodeOutput
+#' @export
 rcodeOutput <- function(outputId) {
   tagList(
     rcodeHighlightDeps(),

--- a/R/output-rmd.R
+++ b/R/output-rmd.R
@@ -67,7 +67,7 @@ renderRmd <- function(
 #' @importFrom htmltools tagList
 #' @importFrom shiny uiOutput
 #'
-#' @export rmdOutput
+#' @export
 rmdOutput <- function(outputId) {
   tagList(
     rmdHighlightDeps(),

--- a/R/output-rmd.R
+++ b/R/output-rmd.R
@@ -1,20 +1,54 @@
 #' Render R Markdown with syntax highlighting
 #'
-#' Description TBA
+#' Renders R Markdown with syntax highlighting using the highlight.js library.
 #'
 #' @inheritParams shiny::renderText
-#' @param outputArgs TBA
-#' @param delay TBA
+#' @param outputArgs List of additional arguments to pass to the
+#'   output function.
+#' @param delay Delay in milliseconds before syntax highlighting starts.
 #'
-#' @return TBA
+#' @return A render function similar to [shiny::renderText()].
 #'
 #' @importFrom shiny exprToFunction markRenderFunction
 #'
-#' @export renderRmd
+#' @export
 #'
 #' @examples
-#' NULL
-renderRmd <- function(expr, env = parent.frame(), quoted = FALSE, outputArgs = list(), delay = 100) {
+#' if (interactive()) {
+#'   library("shiny")
+#'
+#'   ui <- fluidPage(
+#'     fluidRow(
+#'       column(
+#'         4,
+#'         textAreaInput(
+#'           "rmd_in",
+#'           label = NULL,
+#'           width = "100%", height = "500px",
+#'           value = "---\ntitle: Title\noutput: pdf_document\n---\n\n# Heading"
+#'         )
+#'       ),
+#'       column(
+#'         8,
+#'         rmdOutput("rmd_out")
+#'       )
+#'     )
+#'   )
+#'
+#'   server <- function(input, output) {
+#'     output$rmd_out <- renderRmd({
+#'       htmltools::htmlEscape(input$rmd_in)
+#'     })
+#'   }
+#'
+#'   shinyApp(ui = ui, server = server)
+#' }
+renderRmd <- function(
+    expr,
+    env = parent.frame(),
+    quoted = FALSE,
+    outputArgs = list(),
+    delay = 100) {
   func <- exprToFunction(expr, env, quoted)
   renderFunc <- function(shinysession, name, ...) {
     value <- func()

--- a/R/run.R
+++ b/R/run.R
@@ -2,15 +2,16 @@
 #'
 #' @inheritParams shiny::runApp
 #'
-#' @return TBA
+#' @return An object that represents the app.
+#'   Printing the object or passing it to [shiny::runApp()] will run the app.
 #'
 #' @importFrom shiny shinyAppFile
 #'
-#' @export run_app
+#' @export
 #'
 #' @examples
-#' \dontrun{
-#' gMCPShiny::run_app()
+#' if (interactive()) {
+#'   gMCPShiny::run_app()
 #' }
 run_app <- function(port = getOption("shiny.port")) {
   shiny::shinyAppFile(

--- a/R/sanitize-filename.R
+++ b/R/sanitize-filename.R
@@ -3,12 +3,12 @@
 #' Sanitizes file name (without the extension part).
 #' Ported and modified from `fs::path_sanitize()`.
 #'
-#' @param filename TBA
-#' @param replacement TBA
+#' @param filename Input file name.
+#' @param replacement Replacement for illegal characters.
 #'
-#' @return TBA
+#' @return Sanitized file name.
 #'
-#' @export sanitize_filename
+#' @export
 #'
 #' @examples
 #' x <- " znul/zzz.z>z/\\z "

--- a/man/arithmetic_to_numeric.Rd
+++ b/man/arithmetic_to_numeric.Rd
@@ -7,10 +7,10 @@
 arithmetic_to_numeric(x)
 }
 \arguments{
-\item{x}{character string containing arithmetic operators}
+\item{x}{Character string containing arithmetic operators.}
 }
 \value{
-TBA
+The numeric value from evaluating the arithmetic expression.
 }
 \description{
 Convert arithmetic (character) format to numeric

--- a/man/df2graph.Rd
+++ b/man/df2graph.Rd
@@ -2,21 +2,29 @@
 % Please edit documentation in R/df2graph.R
 \name{df2graph}
 \alias{df2graph}
-\title{df2graph}
+\title{Convert transitions data frame into an hgraph matrix}
 \usage{
 df2graph(namesH, df)
 }
 \arguments{
-\item{namesH}{TBA}
+\item{namesH}{Hypothesis names.}
 
-\item{df}{TBA}
+\item{df}{Input data frame of transitions.}
 }
 \value{
-TBA
+An hgraph matrix.
 }
 \description{
-Description TBA
+Convert transitions data frame into an hgraph matrix,
+given all the hypothesis names, with transition weights evaluated.
 }
 \examples{
-NULL
+df2graph(
+  namesH = paste0("H", 1:6),
+  df = data.frame(
+    From = paste0("H", 1:4),
+    To = paste0("H", c(2:4, 1)),
+    Weight = rep(1, 4)
+  )
+)
 }

--- a/man/fileButtonInput.Rd
+++ b/man/fileButtonInput.Rd
@@ -44,11 +44,18 @@ object.}
 \item{placeholder}{The text to show before a file has been uploaded.}
 }
 \value{
-TBA
+Button for file input.
 }
 \description{
-File input but with only the button
+File input but with only the button.
 }
 \examples{
-NULL
+fileButtonInput(
+  "restore",
+  label = NULL,
+  buttonLabel = "Restore",
+  multiple = FALSE,
+  accept = ".rds",
+  width = "50\%"
+)
 }

--- a/man/headerCard.Rd
+++ b/man/headerCard.Rd
@@ -7,16 +7,18 @@
 headerCard(title, ...)
 }
 \arguments{
-\item{title}{TBA}
+\item{title}{Card title.}
 
-\item{...}{TBA}
+\item{...}{List of elements to include in the body of the card.}
 }
 \value{
-TBA
+Card element with header and body.
 }
 \description{
-Card with header
+Card with header (Bootstrap 5).
 }
 \examples{
-NULL
+if (interactive()) {
+  headerCard("Card title", "Card body")
+}
 }

--- a/man/helpLink.Rd
+++ b/man/helpLink.Rd
@@ -7,14 +7,14 @@
 helpLink(href)
 }
 \arguments{
-\item{href}{TBA}
+\item{href}{URL to open.}
 }
 \value{
-TBA
+Link element.
 }
 \description{
 Help link with an icon and opens in a new window or tab.
 }
 \examples{
-NULL
+helpLink("https://en.wikipedia.org/wiki/List_of_Unicode_characters")
 }

--- a/man/helpPopover.Rd
+++ b/man/helpPopover.Rd
@@ -7,16 +7,19 @@
 helpPopover(title, content)
 }
 \arguments{
-\item{title}{TBA}
+\item{title}{Title of the popover.}
 
-\item{content}{TBA}
+\item{content}{Content of the popover.}
 }
 \value{
-TBA
+Popover element.
 }
 \description{
-Help popovers (with question mark icon)
+Help popovers with question mark icon (Bootstrap 5).
 }
 \examples{
-NULL
+helpPopover(
+  "digits",
+  "Number of digits past the decimal."
+)
 }

--- a/man/hgraph_palette.Rd
+++ b/man/hgraph_palette.Rd
@@ -12,18 +12,20 @@ hgraph_palette(
 )
 }
 \arguments{
-\item{pal_name}{Color palette name}
+\item{pal_name}{Color palette name.}
 
-\item{n}{How many different colors for the selected color palette}
+\item{n}{How many different colors for the selected color palette?}
 
 \item{alpha}{Transparency level, a real number in (0, 1].}
 }
 \value{
-TBA
+A vector of color hex values.
 }
 \description{
-Adaptive color palette generator for hGraph using \code{pal_adaptive()} and \code{pal_ramp()}.
+Adaptive color palette generator for hGraph using
+\code{pal_adaptive()} and \code{pal_ramp()}.
 }
 \examples{
-NULL
+hgraph_palette("gray", n = 10)
+hgraph_palette("Okabe-Ito", n = 15)
 }

--- a/man/matrixButtonGroup.Rd
+++ b/man/matrixButtonGroup.Rd
@@ -13,16 +13,16 @@ addMatrixRow(x)
 delMatrixRow(x)
 }
 \arguments{
-\item{inputId}{TBA}
+\item{inputId}{ID of the matrix input.}
 
-\item{x}{TBA}
+\item{x}{Name of the matrix input to add a row to or delete a row from.}
 }
 \value{
-TBA
+A matrix button group.
 }
 \description{
-Buttons to add/delete rows and reset a matrix input
+Buttons to add/delete rows and reset a matrix input.
 }
 \examples{
-NULL
+matrixButtonGroup("matrix")
 }

--- a/man/navbarFluidPage.Rd
+++ b/man/navbarFluidPage.Rd
@@ -82,24 +82,29 @@ default).}
 This will be used as the lang in the \code{<html>} tag, as in \code{<html lang="en">}.
 The default (NULL) results in an empty string.}
 
-\item{brand_image}{TBA}
+\item{brand_image}{Path to the brand image.}
 
-\item{brand_image_width}{TBA}
+\item{brand_image_width}{Width of the brand image in pixels.}
 
-\item{brand_image_height}{TBA}
+\item{brand_image_height}{Height of the brand image in pixels.}
 }
 \value{
-TBA
+A page with a top level navigation bar within a fluid container.
 }
 \description{
-Slightly modified from shiny::navbarPage to support:
+Slightly modified from \code{\link[shiny:navbarPage]{shiny::navbarPage()}} to support:
 \itemize{
-\item navbar inside a fluid container instead of full width
-\item brand image before title.
+\item Navbar inside a fluid container instead of full width.
+\item Brand image before title.
 }
 }
 \examples{
-NULL
+library(shiny)
 
-
+navbarFluidPage(
+  "App Title",
+  tabPanel("Plot"),
+  tabPanel("Summary"),
+  tabPanel("Table")
+)
 }

--- a/man/renderRcode.Rd
+++ b/man/renderRcode.Rd
@@ -28,18 +28,47 @@ will be used when \code{expr} is evaluated. If \code{expr} is a quosure and you
 would like to use its expression as a value for \code{expr}, then you must set
 \code{quoted} to \code{TRUE}.}
 
-\item{outputArgs}{TBA}
+\item{outputArgs}{List of additional arguments to pass to the
+output function.}
 
-\item{delay}{TBA}
+\item{delay}{Delay in milliseconds before syntax highlighting starts.}
 
 \item{outputId}{Output variable to read the R code from.}
 }
 \value{
-TBA
+A render function similar to \code{\link[shiny:renderPrint]{shiny::renderText()}}.
 }
 \description{
-Description TBA
+Renders R code with syntax highlighting using the highlight.js library.
 }
 \examples{
-NULL
+if (interactive()) {
+  library("shiny")
+
+  ui <- fluidPage(
+    fluidRow(
+      column(
+        4,
+        textAreaInput(
+          "rcode_in",
+          label = NULL,
+          width = "100\%", height = "300px",
+          value = "library('shiny')\n\nset.seed(42)\nx <- runif(10)"
+        )
+      ),
+      column(
+        8,
+        rcodeOutput("rcode_out")
+      )
+    )
+  )
+
+  server <- function(input, output) {
+    output$rcode_out <- renderRcode({
+      htmltools::htmlEscape(input$rcode_in)
+    })
+  }
+
+  shinyApp(ui = ui, server = server)
+}
 }

--- a/man/renderRmd.Rd
+++ b/man/renderRmd.Rd
@@ -28,18 +28,47 @@ will be used when \code{expr} is evaluated. If \code{expr} is a quosure and you
 would like to use its expression as a value for \code{expr}, then you must set
 \code{quoted} to \code{TRUE}.}
 
-\item{outputArgs}{TBA}
+\item{outputArgs}{List of additional arguments to pass to the
+output function.}
 
-\item{delay}{TBA}
+\item{delay}{Delay in milliseconds before syntax highlighting starts.}
 
 \item{outputId}{Output variable to read the R Markdown from.}
 }
 \value{
-TBA
+A render function similar to \code{\link[shiny:renderPrint]{shiny::renderText()}}.
 }
 \description{
-Description TBA
+Renders R Markdown with syntax highlighting using the highlight.js library.
 }
 \examples{
-NULL
+if (interactive()) {
+  library("shiny")
+
+  ui <- fluidPage(
+    fluidRow(
+      column(
+        4,
+        textAreaInput(
+          "rmd_in",
+          label = NULL,
+          width = "100\%", height = "500px",
+          value = "---\ntitle: Title\noutput: pdf_document\n---\n\n# Heading"
+        )
+      ),
+      column(
+        8,
+        rmdOutput("rmd_out")
+      )
+    )
+  )
+
+  server <- function(input, output) {
+    output$rmd_out <- renderRmd({
+      htmltools::htmlEscape(input$rmd_in)
+    })
+  }
+
+  shinyApp(ui = ui, server = server)
+}
 }

--- a/man/run_app.Rd
+++ b/man/run_app.Rd
@@ -16,13 +16,14 @@ by Google Chrome for being considered unsafe: 3659, 4045, 5060,
 ports will be tried.}
 }
 \value{
-TBA
+An object that represents the app.
+Printing the object or passing it to \code{\link[shiny:runApp]{shiny::runApp()}} will run the app.
 }
 \description{
 Run Shiny app
 }
 \examples{
-\dontrun{
-gMCPShiny::run_app()
+if (interactive()) {
+  gMCPShiny::run_app()
 }
 }

--- a/man/sanitize_filename.Rd
+++ b/man/sanitize_filename.Rd
@@ -7,12 +7,12 @@
 sanitize_filename(filename, replacement = "-")
 }
 \arguments{
-\item{filename}{TBA}
+\item{filename}{Input file name.}
 
-\item{replacement}{TBA}
+\item{replacement}{Replacement for illegal characters.}
 }
 \value{
-TBA
+Sanitized file name.
 }
 \description{
 Sanitizes file name (without the extension part).

--- a/man/textInputAddonRight.Rd
+++ b/man/textInputAddonRight.Rd
@@ -27,15 +27,23 @@ see \code{\link[shiny:validateCssUnit]{validateCssUnit()}}.}
 be entered into the control. Internet Explorer 8 and 9 do not support this
 option.}
 
-\item{addon}{Addon text}
+\item{addon}{Addon text.}
 }
 \value{
-TBA
+Text input with addon on the right side.
 }
 \description{
 Text input with addon on the right side.
-From \url{https://getbootstrap.com/docs/5.2/forms/input-group/}.
 }
 \examples{
-NULL
+textInputAddonRight(
+  "filename",
+  label = "Name of the report:",
+  value = "gMCPShiny",
+  addon = ".Rmd",
+  width = "100\%"
+)
+}
+\references{
+\url{https://getbootstrap.com/docs/5.3/forms/input-group/}
 }

--- a/vignettes/gMCPShiny.Rmd
+++ b/vignettes/gMCPShiny.Rmd
@@ -12,3 +12,6 @@ knitr::opts_chunk$set(
   collapse = TRUE
 )
 ```
+
+Please run `gMCPShiny::run_app()` to start the app.
+This vignette is only a placeholder.


### PR DESCRIPTION
This PR adds all missing fields for exported functions in the roxygen2 documentation previously marked as "TBA".

Now all exported functions have valid title, description, `@param`, `@return`, and `@examples` fields.